### PR TITLE
delegate offset management to Redis

### DIFF
--- a/sparkStreaming-realtime/src/main/resources/config.properties
+++ b/sparkStreaming-realtime/src/main/resources/config.properties
@@ -2,8 +2,8 @@
 kafka.bootstrap-servers=localhost:9092,localhost:9093,localhost:9094
 
 #redis
-#redis.host=hadoop102
-#redis.port=6379
+redis.host=localhost
+redis.port=6379
 
 #ES
 #es.host=hadoop102

--- a/sparkStreaming-realtime/src/main/scala/com/capstone/realtime/util/MyKafkaUtils.scala
+++ b/sparkStreaming-realtime/src/main/scala/com/capstone/realtime/util/MyKafkaUtils.scala
@@ -42,7 +42,8 @@ object MyKafkaUtils {
   )
 
   /**
-    * 基于SparkStreaming消费 ,获取到KafkaDStream , 使用默认的offset
+    * Consuming base on SparkStreaming, use default offset value
+    * return KafkaDStream
     */
   def getKafkaDStream(ssc : StreamingContext , topic: String  , groupId:String  ) ={
     consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG , groupId)
@@ -54,7 +55,7 @@ object MyKafkaUtils {
   }
 
   /**
-    * 基于SparkStreaming消费 ,获取到KafkaDStream , 使用指定的offset
+    * Consuming base on SparkStreaming, use assigned offset value
     */
   def getKafkaDStream(ssc : StreamingContext , topic: String  , groupId:String ,  offsets: Map[TopicPartition, Long]  ) ={
     consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG , groupId)

--- a/sparkStreaming-realtime/src/main/scala/com/capstone/realtime/util/MyOffsetsUtils.scala
+++ b/sparkStreaming-realtime/src/main/scala/com/capstone/realtime/util/MyOffsetsUtils.scala
@@ -24,63 +24,62 @@ import scala.collection.mutable
 object MyOffsetsUtils {
 
   /**
-    * 往Redis中存储offset
-    * 问题： 存的offset从哪来？
+    * Save the offset to Redis
+    * question： Where is the offset from？
     *            从消费到的数据中提取出来的，传入到该方法中。
     *            offsetRanges: Array[OffsetRange]
     *        offset的结构是什么？
-    *            Kafka中offset维护的结构
-    *               groupId + topic + partition => offset
+    *            Kafka中offset维护的结构: key -> val
+    *               key: groupId + topic + partition -> val: offset value
     *            从传入进来的offset中提取关键信息
     *        在redis中怎么存?
     *          类型: hash
     *          key : groupId + topic
-    *          value: partition - offset  ， partition - offset 。。。。
-    *          写入API: hset / hmset
+    *          value: partition + offset  ， partition + offset 。。。。
+    *          写入API: hset / hmset(batch)
     *          读取API: hgetall
     *          是否过期: 不过期
     */
-  def saveOffset( topic : String , groupId : String , offsetRanges: Array[OffsetRange]  ): Unit ={
-    if(offsetRanges != null && offsetRanges.length > 0){
-      val offsets: util.HashMap[String, String] = new util.HashMap[String,String]()
-      for (offsetRange <- offsetRanges) {
-        val partition: Int = offsetRange.partition
-        val endOffset: Long = offsetRange.untilOffset
-        offsets.put(partition.toString,endOffset.toString)
+    def saveOffset( topic : String , groupId : String , offsetRanges: Array[OffsetRange]  ): Unit ={
+      if (offsetRanges != null && offsetRanges.length > 0) {
+        val offsets: util.HashMap[String, String] = new util.HashMap[String,String]()
+        for (offsetRange <- offsetRanges) {
+          val partition: Int = offsetRange.partition
+          val endOffset: Long = offsetRange.untilOffset //end point of this consumption
+          offsets.put(partition.toString, endOffset.toString)
+        }
+        println("Successfully submit offset: " + offsets)
+        //往redis中存
+        val jedis: Jedis = MyRedisUtils.getJedisFromPool()
+        val redisKey : String = s"offsets:$topic:$groupId"
+        jedis.hset(redisKey , offsets)
+        jedis.close()
       }
-      println("提交offset: " + offsets)
-      //往redis中存
-      val jedis: Jedis = MyRedisUtils.getJedisFromPool()
-      val redisKey : String = s"offsets:$topic:$groupId"
-      jedis.hset(redisKey , offsets)
-      jedis.close()
     }
-  }
 
   /**
-    * 从Redis中读取存储的offset
+    * Read the offset value from Redis
     *
-    * 问题:
-    *    如何让SparkStreaming通过指定的offset进行消费?
-    *
-    *    SparkStreaming要求的offset的格式是什么?
-    *                Map[TopicPartition ,Long  ]
+    * question:
+    *    how to let SparkStreaming consume data with designated offset?
+    *    -> what is the offset format for SparkStreaming?
+    *    ans:Map[TopicPartition, Long]
     */
 
-  def readOffset(topic: String, groupId : String ):  Map[TopicPartition ,Long  ] ={
-    val jedis: Jedis = MyRedisUtils.getJedisFromPool()
-    val redisKey : String = s"offsets:$topic:$groupId"
-    val offsets: util.Map[String, String] = jedis.hgetAll(redisKey)
-    println("读取到offset: " + offsets)
-    val results: mutable.Map[TopicPartition, Long] = mutable.Map[TopicPartition ,Long ]()
-    //将java的map转换成scala的map进行迭代
-    import scala.collection.JavaConverters._
-    for ((partition,offset) <- offsets.asScala) {
-      val tp: TopicPartition = new TopicPartition(topic,partition.toInt)
-      results.put(tp, offset.toLong)
+    def readOffset(topic: String, groupId : String ):  Map[TopicPartition, Long] ={
+      val jedis: Jedis = MyRedisUtils.getJedisFromPool()
+      val redisKey : String = s"offsets:$topic:$groupId"
+      val offsets: util.Map[String, String] = jedis.hgetAll(redisKey)
+      println("Successfully read offset: " + offsets)
+      val results: mutable.Map[TopicPartition, Long] = mutable.Map[TopicPartition, Long]()
+      //format java's map to scala's map
+      import scala.collection.JavaConverters._
+      for ((partition, offset) <- offsets.asScala) {
+        val tp: TopicPartition = new TopicPartition(topic, partition.toInt)
+        results.put(tp, offset.toLong)
+      }
+      jedis.close()
+      results.toMap
     }
-    jedis.close()
-    results.toMap
-  }
 
 }


### PR DESCRIPTION
# Description

Delegate offset management to Redis.
MyKafkaUtils.send -> MyOffsetsUtils.saveOffset

|.................|..batch.....|......topic....|
producer -> batch 1 -> partition 1
............... -> batch 2 -> partition 2
............... -> batch 3 -> partition 3

Q: How do we know after MyKafkaUtils.send, the message is correctly send from batch to topic?
> solution 1: use "synchronous" send. After send message from producer to batch, wait until receiving ack then send another message. (Messages are send one after one which is slow) By default Kafka use async send.
Future work: need to maintain idempotency.

> solution 2: MyKafkaUtils.send -> "flush" -> MyOffsetsUtils.saveOffset
use rdd.foreachPartition + MyKafkaUtils.flush()

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

create containers with docker-compose.yaml
https://github.com/2023-VT-Spring-Capstone/kafka/blob/master/kafka/docker-compose.yaml
A Redis container will be listened on 6379 port

Produce data with script using kafka-console-producer, then 
1. run the spring boot application.
<img width="611" alt="image" src="https://user-images.githubusercontent.com/14934562/221401336-7b46bea0-66a8-4212-a8d5-9d5373b860f2.png">

2. stop the application

3. run the application again, check if read offset values is the same as when we stopped the application.
(0=2962, 1=4818, 2= 2835, 3=3910) 👍 
<img width="751" alt="image" src="https://user-images.githubusercontent.com/14934562/221401347-ace9afca-7af0-4af4-bc2f-485353d6e601.png">



**Test Configuration**:
* JDK: java 8 corretto-1.8


# Checklist:
@ztocode @mx90196650 @namaws

