### PR TITLE
TTL and sentiment analysis

### DIFF
--- a/producer/analysis.py
+++ b/producer/analysis.py
@@ -1,33 +1,16 @@
 from kafka import KafkaConsumer, KafkaProducer
-from textblob import TextBlob
 import json
+from elasticsearch import Elasticsearch
+from datetime import datetime
+from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+
+es = Elasticsearch(['http://localhost:9200'], http_auth=('elastic', 'lIaOuoKHcJcM173Ei8U7'), verify_certs=False)
 
 bootstrap_servers = ['localhost:9092', 'localhost:9093', 'localhost:9094']
-input_topic = 'DWD_BASE_LOG'
+input_topic = 'DWD_TOP_LOG'
 output_topic = 'DWD_ANALYZED_LOG'
 consumer_group = 'my_consumer_group'
-
-
-def analyze_sentiment(message):
-    title = message.get('title')
-    if title and len(title.strip()) > 0:
-        # Use TextBlob to calculate sentiment polarity (-1 to 1)
-        blob = TextBlob(title)
-        sentiment_polarity = blob.sentiment.polarity
-        # Classify sentiment as positive, negative, or neutral
-        if sentiment_polarity > 0:
-            sentiment = 'positive'
-        elif sentiment_polarity < 0:
-            sentiment = 'negative'
-        else:
-            sentiment = 'neutral'
-        # Update the message with the new sentiment value
-        message['sentiment'] = sentiment
-    else:
-        message['sentiment'] = 'unknown'
-
-    return message
-
 
 # Create Kafka consumer and producer
 consumer = KafkaConsumer(
@@ -36,19 +19,134 @@ consumer = KafkaConsumer(
     group_id=consumer_group,
     auto_offset_reset='earliest',  # Start reading from the beginning of the topic
     # enable_auto_commit=True,  # Enable automatic offset commit
-    value_deserializer=lambda m: m.decode('utf-8'),  # Decode message values as UTF-8 strings
+    # Decode message values as UTF-8 strings
+    value_deserializer=lambda m: m.decode('utf-8'),
 )
+
+consumer.subscribe([input_topic])
+
 producer = KafkaProducer(bootstrap_servers=bootstrap_servers,
                          value_serializer=lambda m: json.dumps(m).encode('utf-8'))
 
+#sentiment analysis target words
+new_words = {
+    'citron': -4.0,
+    'hidenburg': -4.0,
+    'moon': 4.0,
+    'highs': 2.0,
+    'mooning': 4.0,
+    'long': 2.0,
+    'short': -2.0,
+    'call': 4.0,
+    'calls': 4.0,
+    'put': -4.0,
+    'puts': -4.0,
+    'break': 2.0,
+    'tendie': 2.0,
+    'tendies': 2.0,
+    'town': 2.0,
+    'overvalued': -3.0,
+    'undervalued': 3.0,
+    'buy': 4.0,
+    'sell': -4.0,
+    'gone': -1.0,
+    'gtfo': -1.7,
+    'paper': -1.7,
+    'bullish': 3.7,
+    'bearish': -3.7,
+    'bagholder': -1.7,
+    'stonk': 1.9,
+    'green': 1.9,
+    'money': 1.2,
+    'print': 2.2,
+    'rocket': 2.2,
+    'bull': 2.9,
+    'bear': -2.9,
+    'pumping': -1.0,
+    'sus': -3.0,
+    'offering': -2.3,
+    'rip': -4.0,
+    'downgrade': -3.0,
+    'upgrade': 3.0,
+    'maintain': 1.0,
+    'pump': 1.9,
+    'hot': 1.5,
+    'drop': -2.5,
+    'rebound': 1.5,
+    'crack': 2.5
+}
+
+#some criteria to filter posts
+upvoteRatio = 0.70
+num_comm = 2
+
+
+def classify_sentiment(title, body):
+    compound_title = title['compound']
+    compound_body = body['compound']
+    compound = (compound_title+compound_body*2)/3
+    if compound >= 0.05:
+        return "bullish"
+    elif compound <= -0.05:
+        return "bearish"
+    else:
+        return "neutral"
+
+
+def sentiment_analysis(post):
+    vader = SentimentIntensityAnalyzer()
+    vader.lexicon.update(new_words)
+    if post['upvote_ratio'] >= upvoteRatio and post['num_comments'] >= num_comm:
+        score_title = vader.polarity_scores(post['title'])
+        score_body = vader.polarity_scores(post['body'])
+        score_neg = (score_title['neg']+score_body['neg']*2)/3
+        score_neu = (score_title['neu']+score_body['neu']*2)/3
+        score_pos = (score_title['pos']+score_body['pos']*2)/3
+        score_compound = classify_sentiment(score_title, score_body)
+        if post['author'] is None:
+            post['author'] = "unknown"
+        post_data = {
+            "author": post['author'],
+            "author_flair_text": post['author_flair_text'],
+            "created_time": post['created_time'],
+            "id": post['id'],
+            "is_original": post['is_original'],
+            "is_self": post['is_self'],
+            "permalink": post['permalink'],
+            "title": post['title'],
+            "body": post['body'],
+            "score": post['score'],
+            "upvote_ratio": post['upvote_ratio'],
+            "num_comments": post['num_comments'],
+            "url": post['url'],
+            "subreddit": post['subreddit'],
+            "ticker": post['ticker'],
+            "label": post['label'],
+            "bullish": score_pos,
+            "neutral": score_neu,
+            "bearish": score_neg,
+            "sentiment_labal": score_compound
+        }
+
+        return post_data
+
+#set up time-based-indices for elasticsearch ILM policy
+current_datetime = datetime.now().strftime("%Y-%m-%d")
+index_name = f"post_sentiment_result-{current_datetime}"
 
 def main():
+    # setup_ilm_and_template()
     for message in consumer:
+        print("_______________________")
         message_value = message.value
         print(message_value)
-        sentiment_analysis_result = analyze_sentiment(json.loads(message_value))
+        sentiment_analysis_result = sentiment_analysis(
+            json.loads(message_value))
+        print(sentiment_analysis_result)
         if sentiment_analysis_result:
-            producer.send(output_topic, value=sentiment_analysis_result)
+            #producer.send(output_topic, value=sentiment_analysis_result)
+            es.index(index=index_name, body=sentiment_analysis_result)
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
1. adjusted posts store directly into elasticsearch (optional, easier to test for adding index policy in elasticsearch) 

2. time-based-indices for elasticsearch ILM policy

3. integrated sentiment analysis method  

## Please follow below instructions for setting up index policy in elasticsearch
The following API query can setup new index policy for custom purpose. Here we setup the policy for data will be deleted after 1 day.
```
#set up data policy - data should be deleted after 1 day
PUT _ilm/policy/cleanup-history
{
  "policy": {
    "phases": {
      "hot": {
        "actions": {}
      },
      "delete": {
        "min_age": "1d",
        "actions": {
          "delete": {}
        }
      }
    }
  }
}

#assign policy to existing indices
PUT /reddit_post_sentiment_result-*/_settings?pretty
{
  "lifecycle.name": "cleanup-history"
}

#create new template for new indices -> will automatically apply on any new indices that macht the template
PUT /_template/realtime_post_policy?pretty
{
"index_patterns": ["post_sentiment_result-*"], "settings": { "index.lifecycle.name": "cleanup-history" }
}
```
And using time-based-indices to indexing in elasticsearch
```
#set up time-based-indices for elasticsearch ILM policy
current_datetime = datetime.now().strftime("%Y-%m-%d")
index_name = f"post_sentiment_result-{current_datetime}"
```
store posts directly into elasticsearch
```
es.index(index=index_name, body=sentiment_analysis_result)
```